### PR TITLE
fix(keymaps): extracted keymaps from data file for more modularity

### DIFF
--- a/dev_config.json
+++ b/dev_config.json
@@ -1,0 +1,14 @@
+{
+    "AddItem": {
+        "Key": "A",
+        "Desc": "[dev] add a new Item"
+    },
+    "DeleteItem": {
+        "Key": "D",
+        "Desc": "[dev] delete a Item"
+    },
+    "ChangeEditor": {
+        "Key": "E",
+        "Desc": "[dev] change the default editor"
+    }
+}

--- a/dev_data.json
+++ b/dev_data.json
@@ -1,18 +1,4 @@
 {
   "item": [],
-  "editor": "nvim",
-  "keymaps": {
-    "AddItem": {
-      "Key": "A",
-      "Desc": "add a new Item"
-    },
-    "DeleteItem": {
-      "Key": "D",
-      "Desc": "delete a Item"
-    },
-    "ChangeEditor": {
-      "Key": "E",
-      "Desc": "change the default editor"
-    }
-  }
+  "editor": "nvim"
 }

--- a/v1/app.go
+++ b/v1/app.go
@@ -49,13 +49,14 @@ func initialModel() model {
 
 	flag.Parse()
 	data = data.GetData()
+    keymaps := GetConfig();
 	if !*noDefaultEditor {
 		data.SetDefaultEditor()
 	}
 	editor = data.Editor
 	var (
 		items    []list.Item
-		listKeys = newListKeyMap(data.KeyMaps)
+		listKeys = newListKeyMap(keymaps)
 	)
 	for i := 0; i < len(data.Item); i++ {
 

--- a/v1/keybinds.go
+++ b/v1/keybinds.go
@@ -51,7 +51,7 @@ func GetConfig() KeyMaps {
 	var keymaps KeyMaps
 	file, err := ioutil.ReadFile(configPath(dev))
 	if err != nil {
-		log.Fatalf("failed to open the keymaps file: %e", err)
+        return keymaps
 	}
 
 	err = json.Unmarshal([]byte(file), &keymaps)

--- a/v1/keybinds.go
+++ b/v1/keybinds.go
@@ -41,7 +41,7 @@ func configPath(dev *bool) string {
 	if err != nil {
 		log.Fatal(err)
 	}
-	path := fmt.Sprintf("/home/%s/.config/config.json", user.Username)
+	path := fmt.Sprintf("/home/%s/.config/openup/config.json", user.Username)
 	return path
 }
 

--- a/v1/keybinds.go
+++ b/v1/keybinds.go
@@ -1,6 +1,12 @@
 package v1
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os/user"
+
 	"github.com/charmbracelet/bubbles/key"
 )
 
@@ -24,18 +30,53 @@ type KeyMaps struct {
 	ChangeEditor KeyMap
 }
 
+// get the path to config file
+func configPath(dev *bool) string {
+	if *dev {
+		// change the data file for development & don't change the data.json
+		// template so the install.sh still works
+		return "./dev_config.json"
+	}
+	user, err := user.Current()
+	if err != nil {
+		log.Fatal(err)
+	}
+	path := fmt.Sprintf("/home/%s/.config/config.json", user.Username)
+	return path
+}
+
+// Unmarshal Keymaps in case of more configurations one could extract the
+// configPath and the GetConfig
+func GetConfig() KeyMaps {
+	var keymaps KeyMaps
+	file, err := ioutil.ReadFile(configPath(dev))
+	if err != nil {
+		log.Fatalf("failed to open the keymaps file: %e", err)
+	}
+
+	err = json.Unmarshal([]byte(file), &keymaps)
+
+	if err != nil {
+		log.Fatalf("failed parsing keymaps json: %e", err)
+	}
+	return keymaps
+}
+
 // initialize keymaps from data.json file
 // if data.json file has no keymaps the default keymaps get set
 func newListKeyMap(keyMaps KeyMaps) *ListKeyMap {
-    if keyMaps.DeleteItem.Key == "" {
-        keyMaps.DeleteItem.Key = "D"
-    }
-    if keyMaps.ChangeEditor.Key == "" {
-        keyMaps.ChangeEditor.Key = "E"
-    }
-    if keyMaps.AddItem.Key == "" {
-        keyMaps.AddItem.Key = "A"
-    }
+	if keyMaps.DeleteItem.Key == "" {
+		keyMaps.DeleteItem.Key = "D"
+		keyMaps.DeleteItem.Desc = "delete an item"
+	}
+	if keyMaps.ChangeEditor.Key == "" {
+		keyMaps.ChangeEditor.Key = "E"
+		keyMaps.ChangeEditor.Desc = "change the editor"
+	}
+	if keyMaps.AddItem.Key == "" {
+		keyMaps.AddItem.Key = "A"
+		keyMaps.AddItem.Desc = "add an item"
+	}
 	return &ListKeyMap{
 		deleteItem: key.NewBinding(
 			key.WithKeys(keyMaps.DeleteItem.Key),


### PR DESCRIPTION
## Changes rel. to issue #14 

- added dev_config.json file
- removed keymaps from data.json
- added the option to use a config.json in .config/openup/config.json

## TODO

- [x] use default keymaps when ~/.config/openup/config.json does not exist (not tested tho)
- [ ] add an option to generate a config.json in install script